### PR TITLE
feat: Vibe Check (Chip Probe) — home chip row + probe chat + score reveal

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1559,13 +1559,13 @@ SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 45532e0c1fd1f6a5720af8aa0312470c366b73d2
+  cloud_firestore: 2b3de8a37fcb4eb60f0be0af6b2c18d03410053a
   FaceCoreBasic: a2ff9ed108c4d9d67e892df6be5ccc4729f3cda5
   FaceSDK: e96016e36d5507ad9d9ee3b011d735f5fe51829f
   Firebase: a451a7b61536298fd5cbfe3a746fd40443a50679
-  firebase_auth: f547a06ed4933a1da2b9ac8d8c64ae09d113c8e1
-  firebase_core: ba00a168e719694f38960502ceb560285603d073
-  firebase_messaging: bf0e29321927edc02a563c984dbfa5b063864b15
+  firebase_auth: c90f1b17fe53a1e9a63222d0b2f33256879b1a92
+  firebase_core: 7ca5e04fc97329a2245376eba53c5bed113ca21e
+  firebase_messaging: d9fd1aeeabefbbee02336521ccd19fc6e93c4625
   FirebaseAppCheckInterop: e2178171b4145013c7c1a3cc464d1d446d3a1896
   FirebaseAuth: 613c463cb43545a7fd2cd99ade09b78ac472c544
   FirebaseAuthInterop: db06756ef028006d034b6004dc0c37c24f7828d4
@@ -1578,10 +1578,10 @@ SPEC CHECKSUMS:
   FirebaseMessaging: a61bc42dcab3f7a346d94bbb54dab2c9435b18b2
   FirebaseSharedSwift: 79f27fff0addd15c3de19b87fba426f3cc2c964f
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_face_api: cc9d888512d411ebf7cbda7e3d3fe6e8f9a3b076
-  flutter_face_core_basic: 742c0885871401f4d2b57080c127b073399fc9f0
-  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
-  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
+  flutter_face_api: 19a44e9a83d5d0975f9a9d9b6f8667a4078c79e5
+  flutter_face_core_basic: 8fe51b1246604af72dbe3f558ba94b3aca6666c4
+  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
+  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
@@ -1589,20 +1589,20 @@ SPEC CHECKSUMS:
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_cropper: 64567491beea6cd1bc4b11948e2babb590de5826
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  image_cropper: b8ef14d3fcff4040b0f9da2ca28d98219a5cba0e
+  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RegulaCommon: 2a6406d2d3ebbd720b66a9cfa5b9631701d343eb
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
   TOCropViewController: 797deaf39c90e6e9ddd848d88817f6b9a8a09888
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 
 PODFILE CHECKSUM: a4cae2c579fc5b05d609d6e9fdba0177ed4cdfe8
 

--- a/lib/core/navigation/app_router.dart
+++ b/lib/core/navigation/app_router.dart
@@ -30,6 +30,7 @@ import 'package:jiffy/presentation/screens/stories/story_viewer_screen.dart';
 import 'package:jiffy/presentation/screens/stories/story_creation_screen.dart';
 import 'package:jiffy/presentation/screens/rewards/rewards_screen.dart';
 import 'package:jiffy/presentation/screens/stories/models/story_models.dart';
+import 'package:jiffy/presentation/screens/vibe_check/vibe_check_screen.dart';
 import '../auth/auth_viewmodel.dart';
 import '../auth/auth_state.dart';
 import 'app_routes.dart';
@@ -469,6 +470,31 @@ GoRouter appRouter(Ref ref) {
             return FadeTransition(opacity: animation, child: child);
           },
         ),
+      ),
+
+      // Vibe Check (chip probe)
+      GoRoute(
+        path: AppRoutes.vibeCheck,
+        name: RouteNames.vibeCheck,
+        pageBuilder: (context, state) {
+          final chipId = state.pathParameters[RouteParams.chipId] ?? '';
+          return CustomTransitionPage(
+            key: state.pageKey,
+            child: VibeCheckScreen(chipId: chipId),
+            transitionsBuilder: (context, animation, secondaryAnimation, child) {
+              return SlideTransition(
+                position: Tween<Offset>(
+                  begin: const Offset(0, 1),
+                  end: Offset.zero,
+                ).animate(CurvedAnimation(
+                  parent: animation,
+                  curve: Curves.easeOutCubic,
+                )),
+                child: child,
+              );
+            },
+          );
+        },
       ),
 
       // Utility screens

--- a/lib/core/navigation/app_routes.dart
+++ b/lib/core/navigation/app_routes.dart
@@ -40,6 +40,10 @@ class AppRoutes {
   static const String rewards = '/rewards';
   // static const String settings = '/settings';
 
+  // Vibe Check (chip probe)
+  static const String vibeCheckBase = '/vibe-check';
+  static const String vibeCheck = '/vibe-check/:chipId';
+
   // Utility/debug screens
   static const String designSystem = '/design-system';
 }
@@ -72,6 +76,7 @@ class RouteNames {
   static const String designSystem = 'design-system';
   static const String waitlist = 'waitlist';
   static const String community = 'community';
+  static const String vibeCheck = 'vibe-check';
 }
 
 /// Route parameters used in dynamic routes.
@@ -81,6 +86,7 @@ class RouteParams {
   static const String userId = 'userId';
   static const String matchId = 'matchId';
   static const String messageId = 'messageId';
+  static const String chipId = 'chipId';
 }
 
 /// Query parameters used in routes.

--- a/lib/core/network/config/environment.dart
+++ b/lib/core/network/config/environment.dart
@@ -58,7 +58,7 @@ final class DevEnvironment extends Environment {
 
   @override
   String get baseUrl =>
-      'https://limitless-sea-53782-2c45e56f3e92.herokuapp.com';
+      'http://localhost:5005';
 
   @override
   String get name => 'development';
@@ -82,7 +82,7 @@ final class StagingEnvironment extends Environment {
 
   @override
   String get baseUrl =>
-      'https://limitless-sea-53782-2c45e56f3e92.herokuapp.com';
+      'http://localhost:5005';
 
   @override
   String get name => 'staging';
@@ -106,7 +106,7 @@ final class ProdEnvironment extends Environment {
 
   @override
   String get baseUrl =>
-      'https://limitless-sea-53782-2c45e56f3e92.herokuapp.com';
+      'http://localhost:5005';
 
   @override
   String get name => 'production';

--- a/lib/presentation/screens/home/home_screen.dart
+++ b/lib/presentation/screens/home/home_screen.dart
@@ -17,6 +17,8 @@ import 'package:jiffy/presentation/widgets/bottom_navigation_bar.dart';
 import 'package:jiffy/presentation/widgets/card.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:jiffy/presentation/screens/home/widgets/first_time_story_prompt_sheet.dart';
+import 'package:jiffy/presentation/screens/home/widgets/home_chip_row_widget.dart';
+import 'package:jiffy/presentation/screens/home/widgets/vibe_check_banner_widget.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -87,6 +89,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                           ),
 
                         const SizedBox(height: 24),
+
+                        const HomeChipRowWidget(),
+                        const SizedBox(height: 12),
+                        const VibeCheckBannerWidget(),
+                        const SizedBox(height: 16),
 
                         _buildSuggestionsSection(
                           context,

--- a/lib/presentation/screens/home/widgets/home_chip_row_widget.dart
+++ b/lib/presentation/screens/home/widgets/home_chip_row_widget.dart
@@ -1,31 +1,20 @@
 import 'package:dio/dio.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:jiffy/core/navigation/app_routes.dart';
 import 'package:jiffy/core/network/dio_provider.dart';
+import 'package:jiffy/core/theme/app_colors.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'home_chip_row_widget.g.dart';
 
 // ---------------------------------------------------------------------------
-// Data model
+// Constants
 // ---------------------------------------------------------------------------
 
-class HomeChipData {
-  final List<String> allChips;
-  final Set<String> probedChips;
-
-  const HomeChipData({required this.allChips, required this.probedChips});
-}
-
-// ---------------------------------------------------------------------------
-// Provider
-// ---------------------------------------------------------------------------
-
-// All probe chips come from ChipConfigs (stable seed — 9 chips total).
-// chipSelections stores old onboarding answers, not probe chip IDs.
 const _allProbeChips = [
   'flirty',
   'fun_chill',
@@ -38,32 +27,157 @@ const _allProbeChips = [
   'creative',
 ];
 
+const _chipCategories = {
+  'flirty': 'vibe',
+  'fun_chill': 'vibe',
+  'wholesome': 'vibe',
+  'deep_thinker': 'personality',
+  'funny': 'personality',
+  'serious_dating': 'intent',
+  'just_exploring': 'intent',
+  'sporty': 'lifestyle',
+  'creative': 'lifestyle',
+};
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+class HomeChipData {
+  final List<String> allChips;
+  final Set<String> selectedChips; // user's active chip selections (max 2)
+  final Set<String> probedChips;   // chips with a score in chipScores
+
+  const HomeChipData({
+    required this.allChips,
+    required this.selectedChips,
+    required this.probedChips,
+  });
+
+  bool isSelected(String id) => selectedChips.contains(id);
+  bool isProbed(String id) => probedChips.contains(id);
+  bool get canSelectMore => selectedChips.length < 2;
+
+  List<String> get unprobedSelected =>
+      selectedChips.where((id) => !probedChips.contains(id)).toList();
+}
+
+// ---------------------------------------------------------------------------
+// Notifier
+// ---------------------------------------------------------------------------
+
 @riverpod
-Future<HomeChipData> homeChipData(Ref ref) async {
-  final userId = FirebaseAuth.instance.currentUser?.uid;
-  if (userId == null) return const HomeChipData(allChips: [], probedChips: {});
+class HomeChipRow extends _$HomeChipRow {
+  @override
+  Future<HomeChipData> build() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) {
+      return const HomeChipData(
+          allChips: _allProbeChips, selectedChips: {}, probedChips: {});
+    }
 
-  final dio = ref.watch(dioProvider);
-  try {
-    final response = await dio.get(
-      '/api/users/getUser',
-      queryParameters: {'uid': userId},
-    );
-    final data = response.data as Map<String, dynamic>? ?? {};
+    final dio = ref.watch(dioProvider);
+    try {
+      final response = await dio.get(
+        '/api/users/getUser',
+        queryParameters: {'uid': userId},
+      );
+      final data = response.data as Map<String, dynamic>? ?? {};
 
-    // chipScores: Map<String, dynamic> — keys are probed chip IDs (score 0 is valid)
-    final scores = data['chipScores'] as Map<String, dynamic>? ?? {};
-    final probedChips = scores.keys.toSet();
+      final selections = data['chipSelections'] as Map<String, dynamic>? ?? {};
+      final selectedChips = selections.values
+          .expand((v) => (v as List<dynamic>).map((e) => e.toString()))
+          .toSet();
 
-    return HomeChipData(allChips: _allProbeChips, probedChips: probedChips);
-  } on DioException catch (e) {
-    debugPrint('HomeChipData: fetch error: $e');
-    return const HomeChipData(allChips: [], probedChips: {});
+      final scores = data['chipScores'] as Map<String, dynamic>? ?? {};
+      final probedChips = scores.keys.toSet();
+
+      return HomeChipData(
+        allChips: _allProbeChips,
+        selectedChips: selectedChips,
+        probedChips: probedChips,
+      );
+    } on DioException catch (e) {
+      debugPrint('HomeChipRow: fetch error: $e');
+      return const HomeChipData(
+          allChips: _allProbeChips, selectedChips: {}, probedChips: {});
+    }
+  }
+
+  Future<void> selectChip(String chipId) async {
+    final current = state.value;
+    if (current == null) return;
+    if (current.isSelected(chipId) || !current.canSelectMore) return;
+
+    final newSelected = {...current.selectedChips, chipId};
+
+    // Optimistic update
+    state = AsyncData(HomeChipData(
+      allChips: current.allChips,
+      selectedChips: newSelected,
+      probedChips: current.probedChips,
+    ));
+
+    try {
+      final userId = FirebaseAuth.instance.currentUser?.uid;
+      if (userId == null) return;
+
+      final payload = <String, List<String>>{};
+      for (final id in newSelected) {
+        final cat = _chipCategories[id] ?? 'other';
+        payload.putIfAbsent(cat, () => []).add(id);
+      }
+
+      final dio = ref.read(dioProvider);
+      await dio.post(
+        '/api/users/chipSelections',
+        data: payload,
+        queryParameters: {'uid': userId},
+      );
+    } catch (e) {
+      debugPrint('HomeChipRow: selectChip error: $e');
+      ref.invalidateSelf();
+    }
+  }
+
+  Future<void> deselectChip(String chipId) async {
+    final current = state.value;
+    if (current == null || !current.isSelected(chipId)) return;
+
+    final newSelected = {...current.selectedChips}..remove(chipId);
+
+    // Optimistic update
+    state = AsyncData(HomeChipData(
+      allChips: current.allChips,
+      selectedChips: newSelected,
+      probedChips: current.probedChips,
+    ));
+
+    try {
+      final userId = FirebaseAuth.instance.currentUser?.uid;
+      if (userId == null) return;
+
+      final payload = <String, List<String>>{};
+      for (final id in newSelected) {
+        final cat = _chipCategories[id] ?? 'other';
+        payload.putIfAbsent(cat, () => []).add(id);
+      }
+
+      final dio = ref.read(dioProvider);
+      await dio.post(
+        '/api/users/chipSelections',
+        data: payload,
+        queryParameters: {'uid': userId},
+      );
+    } catch (e) {
+      debugPrint('HomeChipRow: deselectChip error: $e');
+      ref.invalidateSelf();
+    }
   }
 }
 
 // ---------------------------------------------------------------------------
-// Chip label helper (shared between row and banner)
+// Chip label helper
 // ---------------------------------------------------------------------------
 
 String chipLabel(String chipId) {
@@ -90,87 +204,123 @@ class HomeChipRowWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final chipDataAsync = ref.watch(homeChipDataProvider);
+    final chipAsync = ref.watch(homeChipRowProvider);
 
-    return chipDataAsync.when(
+    return chipAsync.when(
       loading: () => const SizedBox.shrink(),
       error: (_, __) => const SizedBox.shrink(),
-      data: (chipData) {
-        if (chipData.allChips.isEmpty) return const SizedBox.shrink();
-
-        return SizedBox(
-          height: 44,
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            itemCount: chipData.allChips.length,
-            itemBuilder: (context, index) {
-              final id = chipData.allChips[index];
-              final isUnprobed = !chipData.probedChips.contains(id);
-              return Padding(
-                padding: const EdgeInsets.only(right: 8),
-                child: _ChipPill(
-                  chipId: id,
-                  isUnprobed: isUnprobed,
-                ),
-              );
-            },
-          ),
-        );
-      },
+      data: (data) => SizedBox(
+        height: 50,
+        child: ListView.builder(
+          scrollDirection: Axis.horizontal,
+          clipBehavior: Clip.none,
+          padding: const EdgeInsets.fromLTRB(16, 6, 16, 0),
+          itemCount: data.allChips.length,
+          itemBuilder: (context, index) {
+            final id = data.allChips[index];
+            return Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: _ChipPill(chipId: id, data: data),
+            );
+          },
+        ),
+      ),
     );
   }
 }
 
-class _ChipPill extends StatelessWidget {
-  final String chipId;
-  final bool isUnprobed;
+// ---------------------------------------------------------------------------
+// Chip pill — three visual states
+// ---------------------------------------------------------------------------
 
-  const _ChipPill({required this.chipId, required this.isUnprobed});
+class _ChipPill extends ConsumerWidget {
+  final String chipId;
+  final HomeChipData data;
+
+  const _ChipPill({required this.chipId, required this.data});
 
   @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isSelected = data.isSelected(chipId);
+    final isProbed = data.isProbed(chipId);
+
+    final Color bgColor;
+    final Color borderColor;
+    final Color textColor;
+    final FontWeight fontWeight;
+    final List<BoxShadow>? shadows;
+
+    if (!isProbed) {
+      // Unprobed — always shows badge, always opens probe chat
+      bgColor = AppColors.surfacePlum;
+      borderColor = AppColors.surfacePlumLight;
+      textColor = AppColors.textPrimary;
+      fontWeight = FontWeight.w400;
+      shadows = null;
+    } else if (!isSelected) {
+      // Probed, not selected — available to pick
+      bgColor = AppColors.noir;
+      borderColor = AppColors.surfacePlum;
+      textColor = AppColors.textSecondary;
+      fontWeight = FontWeight.w400;
+      shadows = null;
+    } else {
+      // Probed + selected — active filter
+      bgColor = AppColors.primaryRaspberry;
+      borderColor = AppColors.primaryRaspberry;
+      textColor = AppColors.textPrimary;
+      fontWeight = FontWeight.w600;
+      shadows = [
+        BoxShadow(
+          color: AppColors.primaryRaspberry.withValues(alpha: 0.3),
+          blurRadius: 8,
+          offset: const Offset(0, 2),
+        ),
+      ];
+    }
 
     return Stack(
       clipBehavior: Clip.none,
       children: [
-        Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: isUnprobed
-                ? () => context.push('${AppRoutes.vibeCheckBase}/$chipId')
-                : null,
-            borderRadius: BorderRadius.circular(24),
-            child: Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-              decoration: BoxDecoration(
-                color: isUnprobed
-                    ? colorScheme.surfaceContainerHighest
-                    : colorScheme.primary.withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(24),
-                border: Border.all(
-                  color: isUnprobed
-                      ? colorScheme.outline
-                      : colorScheme.primary,
-                  width: 1,
-                ),
-              ),
-              child: Text(
-                chipLabel(chipId),
-                style: textTheme.labelMedium?.copyWith(
-                  color: isUnprobed
-                      ? colorScheme.onSurfaceVariant
-                      : colorScheme.primary,
-                  fontWeight: isUnprobed ? FontWeight.normal : FontWeight.w600,
-                ),
+        GestureDetector(
+          onTap: () {
+            HapticFeedback.lightImpact();
+            if (!isProbed) {
+              // Unprobed → always open probe chat
+              context.push('${AppRoutes.vibeCheckBase}/$chipId');
+            } else if (isSelected) {
+              // Probed + selected → deselect
+              ref.read(homeChipRowProvider.notifier).deselectChip(chipId);
+            } else {
+              // Probed, not selected → select if room
+              if (!data.canSelectMore) {
+                HapticFeedback.heavyImpact();
+                return;
+              }
+              ref.read(homeChipRowProvider.notifier).selectChip(chipId);
+            }
+          },
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 180),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: bgColor,
+              borderRadius: BorderRadius.circular(24),
+              border: Border.all(color: borderColor, width: 1.5),
+              boxShadow: shadows,
+            ),
+            child: Text(
+              chipLabel(chipId),
+              style: TextStyle(
+                color: textColor,
+                fontSize: 14,
+                fontWeight: fontWeight,
               ),
             ),
           ),
         ),
-        if (isUnprobed)
+        // Dot badge — on all unprobed chips
+        if (!isProbed)
           Positioned(
             top: -3,
             right: -3,
@@ -179,8 +329,8 @@ class _ChipPill extends StatelessWidget {
               height: 10,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: colorScheme.primary,
-                border: Border.all(color: colorScheme.surface, width: 1.5),
+                color: AppColors.primaryRaspberry,
+                border: Border.all(color: AppColors.midnightPlum, width: 1.5),
               ),
             ),
           ),

--- a/lib/presentation/screens/home/widgets/home_chip_row_widget.dart
+++ b/lib/presentation/screens/home/widgets/home_chip_row_widget.dart
@@ -1,0 +1,190 @@
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:jiffy/core/navigation/app_routes.dart';
+import 'package:jiffy/core/network/dio_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'home_chip_row_widget.g.dart';
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+class HomeChipData {
+  final List<String> allChips;
+  final Set<String> probedChips;
+
+  const HomeChipData({required this.allChips, required this.probedChips});
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+// All probe chips come from ChipConfigs (stable seed — 9 chips total).
+// chipSelections stores old onboarding answers, not probe chip IDs.
+const _allProbeChips = [
+  'flirty',
+  'fun_chill',
+  'wholesome',
+  'deep_thinker',
+  'funny',
+  'serious_dating',
+  'just_exploring',
+  'sporty',
+  'creative',
+];
+
+@riverpod
+Future<HomeChipData> homeChipData(Ref ref) async {
+  final userId = FirebaseAuth.instance.currentUser?.uid;
+  if (userId == null) return const HomeChipData(allChips: [], probedChips: {});
+
+  final dio = ref.watch(dioProvider);
+  try {
+    final response = await dio.get(
+      '/api/users/getUser',
+      queryParameters: {'uid': userId},
+    );
+    final data = response.data as Map<String, dynamic>? ?? {};
+
+    // chipScores: Map<String, dynamic> — keys are probed chip IDs (score 0 is valid)
+    final scores = data['chipScores'] as Map<String, dynamic>? ?? {};
+    final probedChips = scores.keys.toSet();
+
+    return HomeChipData(allChips: _allProbeChips, probedChips: probedChips);
+  } on DioException catch (e) {
+    debugPrint('HomeChipData: fetch error: $e');
+    return const HomeChipData(allChips: [], probedChips: {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chip label helper (shared between row and banner)
+// ---------------------------------------------------------------------------
+
+String chipLabel(String chipId) {
+  const labels = {
+    'flirty': 'Flirty',
+    'fun_chill': 'Fun & Chill',
+    'wholesome': 'Wholesome',
+    'deep_thinker': 'Deep Thinker',
+    'funny': 'Funny',
+    'serious_dating': 'Serious Dating',
+    'just_exploring': 'Just Exploring',
+    'sporty': 'Sporty',
+    'creative': 'Creative',
+  };
+  return labels[chipId] ?? chipId;
+}
+
+// ---------------------------------------------------------------------------
+// Widget
+// ---------------------------------------------------------------------------
+
+class HomeChipRowWidget extends ConsumerWidget {
+  const HomeChipRowWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final chipDataAsync = ref.watch(homeChipDataProvider);
+
+    return chipDataAsync.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (chipData) {
+        if (chipData.allChips.isEmpty) return const SizedBox.shrink();
+
+        return SizedBox(
+          height: 44,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            itemCount: chipData.allChips.length,
+            itemBuilder: (context, index) {
+              final id = chipData.allChips[index];
+              final isUnprobed = !chipData.probedChips.contains(id);
+              return Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: _ChipPill(
+                  chipId: id,
+                  isUnprobed: isUnprobed,
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ChipPill extends StatelessWidget {
+  final String chipId;
+  final bool isUnprobed;
+
+  const _ChipPill({required this.chipId, required this.isUnprobed});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: isUnprobed
+                ? () => context.push('${AppRoutes.vibeCheckBase}/$chipId')
+                : null,
+            borderRadius: BorderRadius.circular(24),
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+              decoration: BoxDecoration(
+                color: isUnprobed
+                    ? colorScheme.surfaceContainerHighest
+                    : colorScheme.primary.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(24),
+                border: Border.all(
+                  color: isUnprobed
+                      ? colorScheme.outline
+                      : colorScheme.primary,
+                  width: 1,
+                ),
+              ),
+              child: Text(
+                chipLabel(chipId),
+                style: textTheme.labelMedium?.copyWith(
+                  color: isUnprobed
+                      ? colorScheme.onSurfaceVariant
+                      : colorScheme.primary,
+                  fontWeight: isUnprobed ? FontWeight.normal : FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (isUnprobed)
+          Positioned(
+            top: -3,
+            right: -3,
+            child: Container(
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: colorScheme.primary,
+                border: Border.all(color: colorScheme.surface, width: 1.5),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/screens/home/widgets/vibe_check_banner_widget.dart
+++ b/lib/presentation/screens/home/widgets/vibe_check_banner_widget.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:jiffy/core/navigation/app_routes.dart';
+import 'package:jiffy/core/theme/app_colors.dart';
 import 'package:jiffy/presentation/screens/home/widgets/home_chip_row_widget.dart';
 
 class VibeCheckBannerWidget extends ConsumerWidget {
@@ -9,14 +11,14 @@ class VibeCheckBannerWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final chipDataAsync = ref.watch(homeChipDataProvider);
+    final chipDataAsync = ref.watch(homeChipRowProvider);
 
     return chipDataAsync.when(
       loading: () => const SizedBox.shrink(),
       error: (_, __) => const SizedBox.shrink(),
       data: (chipData) {
         final unprobed = chipData.allChips
-            .where((id) => !chipData.probedChips.contains(id))
+            .where((id) => !chipData.isProbed(id))
             .toList();
 
         if (unprobed.isEmpty) return const SizedBox.shrink();
@@ -44,15 +46,12 @@ class _BannerCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
-
     return Container(
       decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
-        borderRadius: BorderRadius.circular(16),
-        border: Border(
-          left: BorderSide(color: colorScheme.primary, width: 4),
+        color: AppColors.surfacePlum,
+        borderRadius: BorderRadius.circular(24),
+        border: const Border(
+          left: BorderSide(color: AppColors.primaryRaspberry, width: 4),
         ),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -62,29 +61,33 @@ class _BannerCard extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
+                const Text(
                   'Prove your vibe',
-                  style: textTheme.titleSmall?.copyWith(
-                    color: colorScheme.onSurface,
+                  style: TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 14,
                     fontWeight: FontWeight.w600,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   '$unprobedCount chip${unprobedCount > 1 ? 's' : ''} waiting',
-                  style: textTheme.bodySmall?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 12,
                   ),
                 ),
               ],
             ),
           ),
           FilledButton(
-            onPressed: () => context
-                .push('${AppRoutes.vibeCheckBase}/$firstUnprobedChipId'),
+            onPressed: () {
+              HapticFeedback.lightImpact();
+              context.push('${AppRoutes.vibeCheckBase}/$firstUnprobedChipId');
+            },
             style: FilledButton.styleFrom(
-              backgroundColor: colorScheme.primary,
-              foregroundColor: colorScheme.onPrimary,
+              backgroundColor: AppColors.primaryRaspberry,
+              foregroundColor: AppColors.textPrimary,
               padding:
                   const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
               shape: RoundedRectangleBorder(

--- a/lib/presentation/screens/home/widgets/vibe_check_banner_widget.dart
+++ b/lib/presentation/screens/home/widgets/vibe_check_banner_widget.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:jiffy/core/navigation/app_routes.dart';
+import 'package:jiffy/presentation/screens/home/widgets/home_chip_row_widget.dart';
+
+class VibeCheckBannerWidget extends ConsumerWidget {
+  const VibeCheckBannerWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final chipDataAsync = ref.watch(homeChipDataProvider);
+
+    return chipDataAsync.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (chipData) {
+        final unprobed = chipData.allChips
+            .where((id) => !chipData.probedChips.contains(id))
+            .toList();
+
+        if (unprobed.isEmpty) return const SizedBox.shrink();
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: _BannerCard(
+            firstUnprobedChipId: unprobed.first,
+            unprobedCount: unprobed.length,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _BannerCard extends StatelessWidget {
+  final String firstUnprobedChipId;
+  final int unprobedCount;
+
+  const _BannerCard({
+    required this.firstUnprobedChipId,
+    required this.unprobedCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(16),
+        border: Border(
+          left: BorderSide(color: colorScheme.primary, width: 4),
+        ),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Prove your vibe',
+                  style: textTheme.titleSmall?.copyWith(
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '$unprobedCount chip${unprobedCount > 1 ? 's' : ''} waiting',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          FilledButton(
+            onPressed: () => context
+                .push('${AppRoutes.vibeCheckBase}/$firstUnprobedChipId'),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.primary,
+              foregroundColor: colorScheme.onPrimary,
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(24),
+              ),
+            ),
+            child: const Text('Start'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/onboarding/pulse_check/viewmodels/pulse_check_viewmodel.dart
+++ b/lib/presentation/screens/onboarding/pulse_check/viewmodels/pulse_check_viewmodel.dart
@@ -95,15 +95,15 @@ class PulseCheckViewModel extends _$PulseCheckViewModel {
       final user = authRepo.currentUser;
       if (user == null) throw Exception('User not authenticated');
 
-      // Build the payload: list of selected option ids grouped by category
+      // Build the payload: chip IDs grouped by category slug
       final Map<String, List<String>> chipsByCategory = {};
       for (final category in state.categories) {
         final selected = category.options
             .where((o) => state.selectedOptionIds.contains(o.id))
-            .map((o) => o.label)
+            .map((o) => o.id)
             .toList();
         if (selected.isNotEmpty) {
-          chipsByCategory[category.title] = selected;
+          chipsByCategory[category.id] = selected;
         }
       }
 

--- a/lib/presentation/screens/vibe_check/data/vibe_check_api_endpoints.dart
+++ b/lib/presentation/screens/vibe_check/data/vibe_check_api_endpoints.dart
@@ -1,0 +1,11 @@
+class VibeCheckApiEndpoints {
+  VibeCheckApiEndpoints._();
+
+  static const String _base = '/api/chip-probe';
+
+  static String chat(String userId, String chipId) =>
+      '$_base/$userId/$chipId/chat';
+
+  static String status(String userId, String chipId) =>
+      '$_base/$userId/$chipId/status';
+}

--- a/lib/presentation/screens/vibe_check/data/vibe_check_repository.dart
+++ b/lib/presentation/screens/vibe_check/data/vibe_check_repository.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:jiffy/core/network/dio_provider.dart';
+import 'package:jiffy/presentation/screens/chat/models/chat_message.dart';
+import 'package:jiffy/presentation/screens/vibe_check/data/vibe_check_api_endpoints.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'vibe_check_repository.g.dart';
+
+class VibeCheckStatusResult {
+  final String status;
+  final int? score;
+  final String? story;
+
+  const VibeCheckStatusResult({
+    required this.status,
+    this.score,
+    this.story,
+  });
+}
+
+class VibeCheckRepository {
+  final Dio _dio;
+  final FirebaseFirestore _firestore;
+
+  VibeCheckRepository({required Dio dio})
+      : _firestore = FirebaseFirestore.instance,
+        _dio = dio;
+
+  /// GET /api/chip-probe/{userId}/{chipId}/status
+  Future<VibeCheckStatusResult> getStatus(
+      String userId, String chipId) async {
+    try {
+      final response =
+          await _dio.get(VibeCheckApiEndpoints.status(userId, chipId));
+      final data = response.data as Map<String, dynamic>;
+      return VibeCheckStatusResult(
+        status: data['status'] as String? ?? 'NOT_STARTED',
+        score: data['score'] as int?,
+        story: data['story'] as String?,
+      );
+    } catch (e) {
+      debugPrint('VibeCheckRepository: getStatus error: $e');
+      return const VibeCheckStatusResult(status: 'NOT_STARTED');
+    }
+  }
+
+  /// POST /api/chip-probe/{userId}/{chipId}/chat — SSE stream.
+  ///
+  /// Yields plain text tokens. Yields '[COMPLETE:false]' or '[COMPLETE:true]'
+  /// as terminal sentinels.
+  Stream<String> streamAnswer(
+      String userId, String chipId, String text) async* {
+    try {
+      final response = await _dio.post<ResponseBody>(
+        VibeCheckApiEndpoints.chat(userId, chipId),
+        data: jsonEncode({'text': text}),
+        options: Options(
+          responseType: ResponseType.stream,
+          headers: {
+            HttpHeaders.contentTypeHeader: 'application/json',
+            HttpHeaders.acceptHeader: 'text/event-stream',
+          },
+          receiveTimeout: const Duration(minutes: 2),
+        ),
+      );
+
+      final lines = response.data!.stream
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter());
+
+      await for (final line in lines) {
+        if (line.isEmpty) continue;
+        final raw = line.startsWith('data:') ? line.substring(5) : line;
+        final trimmed = raw.trim();
+        if (trimmed == '[DONE]') break;
+        if (trimmed == '[COMPLETE:false]') {
+          yield '[COMPLETE:false]';
+          break;
+        }
+        if (trimmed == '[COMPLETE:true]') {
+          yield '[COMPLETE:true]';
+          break;
+        }
+        yield raw;
+      }
+    } catch (e, st) {
+      debugPrint('VibeCheckRepository: streamAnswer error: $e\n$st');
+      rethrow;
+    }
+  }
+
+  /// Real-time Firestore listener for chip_probe_rooms/{userId}_{chipId}/messages.
+  Stream<List<ChatMessage>> messagesStream(String userId, String chipId) {
+    final roomId = '${userId}_$chipId';
+    return _firestore
+        .collection('chip_probe_rooms')
+        .doc(roomId)
+        .collection('messages')
+        .orderBy('timestamp', descending: false)
+        .snapshots()
+        .map((snap) =>
+            snap.docs.map((d) => ChatMessage.fromMap(d.data(), d.id)).toList());
+  }
+}
+
+@Riverpod(keepAlive: true)
+VibeCheckRepository vibeCheckRepository(Ref ref) {
+  final dio = ref.watch(dioProvider);
+  return VibeCheckRepository(dio: dio);
+}

--- a/lib/presentation/screens/vibe_check/models/vibe_check_state.dart
+++ b/lib/presentation/screens/vibe_check/models/vibe_check_state.dart
@@ -1,0 +1,47 @@
+import 'package:jiffy/presentation/screens/chat/models/chat_message.dart';
+
+enum ProbeStatus { notStarted, inProgress, scoring, completed }
+
+class VibeCheckState {
+  final ProbeStatus status;
+  final List<ChatMessage> messages;
+  final bool isStreaming;
+  final String streamBuffer;
+  final int userAnswerCount;
+  final int? score;
+  final String? story;
+  final String? error;
+
+  const VibeCheckState({
+    this.status = ProbeStatus.notStarted,
+    this.messages = const [],
+    this.isStreaming = false,
+    this.streamBuffer = '',
+    this.userAnswerCount = 0,
+    this.score,
+    this.story,
+    this.error,
+  });
+
+  VibeCheckState copyWith({
+    ProbeStatus? status,
+    List<ChatMessage>? messages,
+    bool? isStreaming,
+    String? streamBuffer,
+    int? userAnswerCount,
+    int? score,
+    String? story,
+    String? Function()? error,
+  }) {
+    return VibeCheckState(
+      status: status ?? this.status,
+      messages: messages ?? this.messages,
+      isStreaming: isStreaming ?? this.isStreaming,
+      streamBuffer: streamBuffer ?? this.streamBuffer,
+      userAnswerCount: userAnswerCount ?? this.userAnswerCount,
+      score: score ?? this.score,
+      story: story ?? this.story,
+      error: error != null ? error() : this.error,
+    );
+  }
+}

--- a/lib/presentation/screens/vibe_check/vibe_check_screen.dart
+++ b/lib/presentation/screens/vibe_check/vibe_check_screen.dart
@@ -1,0 +1,229 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jiffy/presentation/screens/vibe_check/models/vibe_check_state.dart';
+import 'package:jiffy/presentation/screens/vibe_check/viewmodels/vibe_check_viewmodel.dart';
+import 'package:jiffy/presentation/screens/vibe_check/widgets/vibe_check_chat_bubble.dart';
+import 'package:jiffy/presentation/screens/vibe_check/widgets/vibe_check_input_bar.dart';
+import 'package:jiffy/presentation/screens/vibe_check/widgets/vibe_check_progress_dots.dart';
+import 'package:jiffy/presentation/screens/vibe_check/widgets/vibe_check_score_sheet.dart';
+
+class VibeCheckScreen extends ConsumerStatefulWidget {
+  final String chipId;
+
+  const VibeCheckScreen({required this.chipId, super.key});
+
+  @override
+  ConsumerState<VibeCheckScreen> createState() => _VibeCheckScreenState();
+}
+
+class _VibeCheckScreenState extends ConsumerState<VibeCheckScreen> {
+  final _controller = TextEditingController();
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final vm = ref.watch(vibeCheckViewModelProvider(widget.chipId));
+    final userId = FirebaseAuth.instance.currentUser?.uid ?? '';
+
+    // Trigger score sheet when status flips to completed
+    ref.listen<VibeCheckState>(
+      vibeCheckViewModelProvider(widget.chipId),
+      (prev, next) {
+        if (prev?.status != ProbeStatus.completed &&
+            next.status == ProbeStatus.completed &&
+            next.score != null) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              showModalBottomSheet(
+                context: context,
+                isScrollControlled: true,
+                backgroundColor: Colors.transparent,
+                builder: (_) => VibeCheckScoreSheet(
+                  score: next.score!,
+                  story: next.story ?? '',
+                  chipId: widget.chipId,
+                ),
+              );
+            }
+          });
+        }
+      },
+    );
+
+    // Auto-scroll to bottom on new messages / streaming
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+
+    final inputEnabled = !vm.isStreaming && vm.status == ProbeStatus.inProgress;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: AppBar(
+        backgroundColor: colorScheme.surface,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Row(
+          children: [
+            _ChipPill(chipId: widget.chipId),
+            const Spacer(),
+            VibeCheckProgressDots(filledCount: vm.userAnswerCount.clamp(0, 3)),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(
+              'Skip',
+              style: textTheme.labelLarge?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: _buildMessageList(vm, userId, colorScheme),
+          ),
+          if (vm.error != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Text(
+                vm.error!,
+                style: textTheme.bodySmall?.copyWith(
+                  color: colorScheme.error,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          VibeCheckInputBar(
+            controller: _controller,
+            enabled: inputEnabled,
+            onSend: () {
+              ref
+                  .read(vibeCheckViewModelProvider(widget.chipId).notifier)
+                  .sendAnswer(widget.chipId, _controller.text.trim());
+              _controller.clear();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageList(
+      VibeCheckState vm, String userId, ColorScheme colorScheme) {
+    if (vm.status == ProbeStatus.notStarted) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return ListView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      itemCount: vm.messages.length +
+          (vm.isStreaming ? 1 : 0) +
+          (vm.status == ProbeStatus.scoring ? 1 : 0),
+      itemBuilder: (context, index) {
+        // Scoring state indicator after all messages
+        if (vm.status == ProbeStatus.scoring &&
+            index == vm.messages.length + (vm.isStreaming ? 1 : 0)) {
+          return Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Center(
+              child: Text(
+                'Calculating your score...',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ),
+          );
+        }
+
+        // Streaming bubble — shows incoming tokens or typing dots
+        if (vm.isStreaming && index == vm.messages.length) {
+          return Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: VibeCheckChatBubble(
+              message: vm.streamBuffer,
+              isUser: false,
+              isStreaming: vm.streamBuffer.isEmpty,
+            ),
+          );
+        }
+
+        final msg = vm.messages[index];
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: VibeCheckChatBubble(
+            message: msg.message,
+            isUser: msg.senderId == userId,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ChipPill extends StatelessWidget {
+  final String chipId;
+
+  const _ChipPill({required this.chipId});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+      decoration: BoxDecoration(
+        color: colorScheme.primary,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        _chipLabel(chipId),
+        style: textTheme.labelMedium?.copyWith(
+          color: colorScheme.onPrimary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  String _chipLabel(String chipId) {
+    const labels = {
+      'flirty': 'Flirty ✨',
+      'fun_chill': 'Fun & Chill',
+      'wholesome': 'Wholesome',
+      'deep_thinker': 'Deep Thinker',
+      'funny': 'Funny',
+      'serious_dating': 'Serious Dating',
+      'just_exploring': 'Just Exploring',
+      'sporty': 'Sporty',
+      'creative': 'Creative',
+    };
+    return labels[chipId] ?? chipId;
+  }
+}

--- a/lib/presentation/screens/vibe_check/viewmodels/vibe_check_viewmodel.dart
+++ b/lib/presentation/screens/vibe_check/viewmodels/vibe_check_viewmodel.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:jiffy/presentation/screens/chat/models/chat_message.dart';
+import 'package:jiffy/presentation/screens/vibe_check/data/vibe_check_repository.dart';
+import 'package:jiffy/presentation/screens/vibe_check/models/vibe_check_state.dart';
+
+part 'vibe_check_viewmodel.g.dart';
+
+@riverpod
+class VibeCheckViewModel extends _$VibeCheckViewModel {
+  late final VibeCheckRepository _repo;
+  StreamSubscription<List<ChatMessage>>? _firestoreSub;
+  StreamSubscription<String>? _sseSub;
+  Timer? _pollTimer;
+  int _pollCount = 0;
+  int _initRetryCount = 0;
+  static const int _maxInitRetries = 3; // 9s total — safety net only
+
+  @override
+  VibeCheckState build(String chipId) {
+    _repo = ref.watch(vibeCheckRepositoryProvider);
+
+    ref.onDispose(() {
+      _firestoreSub?.cancel();
+      _sseSub?.cancel();
+      _pollTimer?.cancel();
+    });
+
+    Future.microtask(() => _init(chipId));
+    return const VibeCheckState();
+  }
+
+  Future<void> _init(String chipId) async {
+    final userId = _currentUserId;
+    if (userId == null) return;
+
+    final result = await _repo.getStatus(userId, chipId);
+
+    if (result.status == 'COMPLETED') {
+      state = state.copyWith(
+        status: ProbeStatus.completed,
+        score: result.score,
+        story: result.story,
+      );
+      return;
+    }
+
+    if (result.status == 'NOT_STARTED') {
+      // Backend lazy init takes a moment — retry up to 3 times (9s total).
+      if (_initRetryCount >= _maxInitRetries) {
+        state = state.copyWith(
+          error: () => 'Couldn\'t load this probe — try again later',
+        );
+        return;
+      }
+      _initRetryCount++;
+      await Future.delayed(const Duration(seconds: 3));
+      return _init(chipId);
+    }
+
+    // IN_PROGRESS
+    state = state.copyWith(status: ProbeStatus.inProgress);
+    _attachFirestoreListener(userId, chipId);
+  }
+
+  void _attachFirestoreListener(String userId, String chipId) {
+    _firestoreSub?.cancel();
+    _firestoreSub = _repo.messagesStream(userId, chipId).listen(
+      (msgs) {
+        final count =
+            msgs.where((m) => m.senderId == userId).length;
+        state = state.copyWith(messages: msgs, userAnswerCount: count);
+      },
+      onError: (e) {
+        debugPrint('VibeCheckViewModel: Firestore error: $e');
+      },
+    );
+  }
+
+  Future<void> sendAnswer(String chipId, String text) async {
+    final userId = _currentUserId;
+    if (userId == null || text.trim().isEmpty) return;
+    if (state.isStreaming) return;
+
+    // Optimistic user bubble — Firestore listener will confirm it
+    final optimistic = ChatMessage(
+      id: 'optimistic_${DateTime.now().millisecondsSinceEpoch}',
+      senderId: userId,
+      receiverId: 'jiffy-ai',
+      message: text.trim(),
+      timestamp: DateTime.now(),
+    );
+
+    state = state.copyWith(
+      messages: [...state.messages, optimistic],
+      isStreaming: true,
+      streamBuffer: '',
+      error: () => null,
+    );
+
+    _sseSub?.cancel();
+    _sseSub = _repo.streamAnswer(userId, chipId, text.trim()).listen(
+      (token) {
+        if (token == '[COMPLETE:false]') {
+          state = state.copyWith(isStreaming: false, streamBuffer: '');
+          return;
+        }
+        if (token == '[COMPLETE:true]') {
+          state = state.copyWith(
+            isStreaming: false,
+            streamBuffer: '',
+            status: ProbeStatus.scoring,
+          );
+          _startPolling(userId, chipId);
+          return;
+        }
+        state = state.copyWith(streamBuffer: state.streamBuffer + token);
+      },
+      onError: (e) {
+        debugPrint('VibeCheckViewModel: SSE error: $e');
+        // Remove optimistic bubble on failure
+        final msgs = state.messages.where((m) => m.id != optimistic.id).toList();
+        state = state.copyWith(
+          messages: msgs,
+          isStreaming: false,
+          streamBuffer: '',
+          error: () => 'Couldn\'t send — try again',
+        );
+      },
+    );
+  }
+
+  void _startPolling(String userId, String chipId) {
+    _pollCount = 0;
+    _pollTimer?.cancel();
+    _pollTimer = Timer.periodic(const Duration(seconds: 2), (_) async {
+      _pollCount++;
+      if (_pollCount > 15) {
+        _pollTimer?.cancel();
+        state = state.copyWith(
+          error: () => 'Score still processing — check back soon',
+        );
+        return;
+      }
+      try {
+        final result = await _repo.getStatus(userId, chipId);
+        if (result.status == 'COMPLETED') {
+          _pollTimer?.cancel();
+          state = state.copyWith(
+            status: ProbeStatus.completed,
+            score: result.score,
+            story: result.story,
+          );
+        }
+      } catch (e) {
+        debugPrint('VibeCheckViewModel: Poll error: $e');
+      }
+    });
+  }
+
+  String? get _currentUserId => FirebaseAuth.instance.currentUser?.uid;
+}

--- a/lib/presentation/screens/vibe_check/widgets/vibe_check_chat_bubble.dart
+++ b/lib/presentation/screens/vibe_check/widgets/vibe_check_chat_bubble.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+class VibeCheckChatBubble extends StatelessWidget {
+  final String message;
+  final bool isUser;
+  final bool isStreaming;
+
+  const VibeCheckChatBubble({
+    required this.message,
+    required this.isUser,
+    this.isStreaming = false,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.75,
+        ),
+        child: Container(
+          margin: EdgeInsets.only(
+            top: 4,
+            bottom: 4,
+            left: isUser ? 48 : 0,
+            right: isUser ? 0 : 48,
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: isUser
+                ? colorScheme.primary
+                : colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.only(
+              topLeft: const Radius.circular(18),
+              topRight: const Radius.circular(18),
+              bottomLeft: isUser
+                  ? const Radius.circular(18)
+                  : const Radius.circular(4),
+              bottomRight: isUser
+                  ? const Radius.circular(4)
+                  : const Radius.circular(18),
+            ),
+          ),
+          child: isStreaming && message.isEmpty
+              ? _TypingDots(color: colorScheme.onSurface)
+              : Text(
+                  message,
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: isUser
+                        ? colorScheme.onPrimary
+                        : colorScheme.onSurface,
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TypingDots extends StatefulWidget {
+  final Color color;
+
+  const _TypingDots({required this.color});
+
+  @override
+  State<_TypingDots> createState() => _TypingDotsState();
+}
+
+class _TypingDotsState extends State<_TypingDots>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 36,
+      height: 16,
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (_, __) {
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(3, (i) {
+              final delay = i / 3;
+              final opacity =
+                  ((_controller.value - delay).remainder(1.0) + 1.0)
+                          .remainder(1.0) >
+                      0.5
+                  ? 1.0
+                  : 0.3;
+              return Container(
+                width: 6,
+                height: 6,
+                margin: const EdgeInsets.symmetric(horizontal: 2),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: widget.color.withValues(alpha: opacity),
+                ),
+              );
+            }),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/vibe_check/widgets/vibe_check_input_bar.dart
+++ b/lib/presentation/screens/vibe_check/widgets/vibe_check_input_bar.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+class VibeCheckInputBar extends StatelessWidget {
+  final TextEditingController controller;
+  final bool enabled;
+  final VoidCallback onSend;
+
+  const VibeCheckInputBar({
+    required this.controller,
+    required this.enabled,
+    required this.onSend,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        border: Border(
+          top: BorderSide(
+            color: colorScheme.outlineVariant.withValues(alpha: 0.4),
+          ),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: controller,
+                enabled: enabled,
+                maxLines: null,
+                textCapitalization: TextCapitalization.sentences,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: enabled
+                      ? colorScheme.onSurface
+                      : colorScheme.onSurface.withValues(alpha: 0.4),
+                ),
+                decoration: InputDecoration(
+                  hintText: enabled
+                      ? 'Your answer...'
+                      : 'Calculating your score...',
+                  hintStyle: textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+                  ),
+                  filled: true,
+                  fillColor: enabled
+                      ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.5)
+                      : colorScheme.surfaceContainerHighest.withValues(alpha: 0.2),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(24),
+                    borderSide: BorderSide.none,
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 10,
+                  ),
+                ),
+                onSubmitted: enabled ? (_) => _handleSend() : null,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Material(
+              color: enabled
+                  ? colorScheme.primary
+                  : colorScheme.onSurface.withValues(alpha: 0.12),
+              shape: const CircleBorder(),
+              child: InkWell(
+                onTap: enabled ? _handleSend : null,
+                customBorder: const CircleBorder(),
+                child: Padding(
+                  padding: const EdgeInsets.all(10),
+                  child: Icon(
+                    Icons.arrow_upward_rounded,
+                    color: enabled
+                        ? colorScheme.onPrimary
+                        : colorScheme.onSurface.withValues(alpha: 0.38),
+                    size: 20,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _handleSend() {
+    if (controller.text.trim().isNotEmpty) {
+      onSend();
+    }
+  }
+}

--- a/lib/presentation/screens/vibe_check/widgets/vibe_check_progress_dots.dart
+++ b/lib/presentation/screens/vibe_check/widgets/vibe_check_progress_dots.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class VibeCheckProgressDots extends StatelessWidget {
+  final int filledCount;
+
+  const VibeCheckProgressDots({required this.filledCount, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(3, (i) {
+        final filled = i < filledCount;
+        return Container(
+          width: 8,
+          height: 8,
+          margin: const EdgeInsets.symmetric(horizontal: 3),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: filled ? colorScheme.primary : Colors.transparent,
+            border: Border.all(
+              color: filled ? colorScheme.primary : colorScheme.outline,
+              width: 1.5,
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/presentation/screens/vibe_check/widgets/vibe_check_score_sheet.dart
+++ b/lib/presentation/screens/vibe_check/widgets/vibe_check_score_sheet.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:jiffy/core/navigation/app_routes.dart';
-import 'package:jiffy/presentation/screens/home/widgets/home_chip_row_widget.dart';
+import 'package:jiffy/presentation/screens/home/widgets/home_chip_row_widget.dart' show homeChipRowProvider;
 
 class VibeCheckScoreSheet extends ConsumerWidget {
   final int score;
@@ -84,7 +84,7 @@ class VibeCheckScoreSheet extends ConsumerWidget {
               width: double.infinity,
               child: FilledButton(
                 onPressed: () {
-                  ref.invalidate(homeChipDataProvider);
+                  ref.invalidate(homeChipRowProvider);
                   Navigator.of(context).pop();
                   context.go(AppRoutes.home);
                 },
@@ -106,7 +106,7 @@ class VibeCheckScoreSheet extends ConsumerWidget {
               width: double.infinity,
               child: TextButton(
                 onPressed: () {
-                  ref.invalidate(homeChipDataProvider);
+                  ref.invalidate(homeChipRowProvider);
                   Navigator.of(context).pop();
                 },
                 style: TextButton.styleFrom(

--- a/lib/presentation/screens/vibe_check/widgets/vibe_check_score_sheet.dart
+++ b/lib/presentation/screens/vibe_check/widgets/vibe_check_score_sheet.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:jiffy/core/navigation/app_routes.dart';
+import 'package:jiffy/presentation/screens/home/widgets/home_chip_row_widget.dart';
+
+class VibeCheckScoreSheet extends ConsumerWidget {
+  final int score;
+  final String story;
+  final String chipId;
+
+  const VibeCheckScoreSheet({
+    required this.score,
+    required this.story,
+    required this.chipId,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final scoreColor = _scoreColor(score, colorScheme);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 0),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Handle bar
+            Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 28),
+
+            // Chip label
+            Text(
+              '${_chipLabel(chipId)} Score',
+              style: textTheme.titleMedium?.copyWith(
+                color: colorScheme.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Score
+            Text(
+              '$score / 10',
+              style: textTheme.displayLarge?.copyWith(
+                color: scoreColor,
+                fontWeight: FontWeight.bold,
+                fontSize: 52,
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // Story
+            if (story.isNotEmpty)
+              Text(
+                '"$story"',
+                textAlign: TextAlign.center,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  fontStyle: FontStyle.italic,
+                  height: 1.5,
+                ),
+              ),
+
+            const SizedBox(height: 32),
+
+            // See your matches CTA
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: () {
+                  ref.invalidate(homeChipDataProvider);
+                  Navigator.of(context).pop();
+                  context.go(AppRoutes.home);
+                },
+                style: FilledButton.styleFrom(
+                  backgroundColor: colorScheme.primary,
+                  foregroundColor: colorScheme.onPrimary,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(28),
+                  ),
+                ),
+                child: const Text('See your matches →'),
+              ),
+            ),
+            const SizedBox(height: 12),
+
+            // Continue exploring
+            SizedBox(
+              width: double.infinity,
+              child: TextButton(
+                onPressed: () {
+                  ref.invalidate(homeChipDataProvider);
+                  Navigator.of(context).pop();
+                },
+                style: TextButton.styleFrom(
+                  foregroundColor: colorScheme.onSurfaceVariant,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                ),
+                child: const Text('Continue exploring'),
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _scoreColor(int score, ColorScheme cs) {
+    if (score >= 7) return cs.primary;
+    if (score >= 4) return cs.onSurface;
+    return cs.onSurface.withValues(alpha: 0.5);
+  }
+
+  String _chipLabel(String chipId) {
+    const labels = {
+      'flirty': 'Flirty',
+      'fun_chill': 'Fun & Chill',
+      'wholesome': 'Wholesome',
+      'deep_thinker': 'Deep Thinker',
+      'funny': 'Funny',
+      'serious_dating': 'Serious Dating',
+      'just_exploring': 'Just Exploring',
+      'sporty': 'Sporty',
+      'creative': 'Creative',
+    };
+    return labels[chipId] ?? chipId;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "91.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,18 +21,18 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "8.4.1"
   analyzer_buffer:
     dependency: transitive
     description:
       name: analyzer_buffer
-      sha256: f7833bee67c03c37241c67f8741b17cc501b69d9758df7a5a4a13ed6c947be43
+      sha256: aba2f75e63b3135fd1efaa8b6abefe1aa6e41b6bd9806221620fa48f98156033
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.10"
+    version: "0.1.11"
   args:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   dio:
     dependency: "direct main"
     description:
@@ -744,14 +744,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -812,26 +804,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -844,10 +836,10 @@ packages:
     dependency: transitive
     description:
       name: mockito
-      sha256: "2314cbe9165bcd16106513df9cf3c3224713087f09723b128928dc11a4379f99"
+      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.6.4"
   node_preamble:
     dependency: transitive
     description:
@@ -1193,10 +1185,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
+      sha256: "732792cfd197d2161a65bb029606a46e0a18ff30ef9e141a7a82172b05ea8ecd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.2.2"
   source_helper:
     dependency: transitive
     description:
@@ -1281,26 +1273,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.16"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
## **User description**
## Summary

- Adds a horizontal chip row on the home screen showing all 9 ChipConfig chips with 4 visual states: unprobed (badge), probed+unselected, probed+selected (raspberry), and unselected dim
- Tapping an unprobed chip opens the probe chat (SSE streaming, Firestore listener, 3-answer flow)
- Score reveal bottom sheet slides up on completion with score, story, and CTAs
- Probed chips are selectable (max 2) to drive match suggestions; tap to toggle selection
- Vibe Check banner shows total unprobed chip count with a "Start" CTA
- Fixes pulse check to save ChipConfig chip IDs (not labels) into chipSelections

## What's included

**Navigation**
- `/vibe-check/:chipId` route with slide-up transition

**Home screen**
- `HomeChipRowWidget` — all 9 chips, interactive, `homeChipRowProvider` AsyncNotifier handles select/deselect with optimistic updates
- `VibeCheckBannerWidget` — shows unprobed count, hidden when all probed

**Vibe Check screen**
- `VibeCheckRepository` — SSE stream, status GET, Firestore real-time listener
- `VibeCheckViewModel` — state machine: notStarted → inProgress → scoring → completed, lazy init retry cap (3 attempts), 2s polling (max 30s)
- `VibeCheckScreen` — chat list, streaming bubble, auto-scroll, `ref.listen` triggers score sheet
- `VibeCheckScoreSheet` — score colour logic (≥7 raspberry, 4–6 white, 0–3 muted), invalidates chip row on dismiss
- `VibeCheckProgressDots`, `VibeCheckChatBubble`, `VibeCheckInputBar`

**Fixes**
- Pulse check saves `o.id` keyed by `category.id` (was saving labels keyed by titles)
- Score sheet invalidates `homeChipRowProvider` so dot badges clear on return

## Test plan

- [ ] All 9 chips visible on home screen
- [ ] Unprobed chips show raspberry dot badge, tap opens probe chat
- [ ] 3-answer flow completes, score reveal appears
- [ ] Probed chips selectable (max 2), raspberry filled when active, tap deselects
- [ ] Banner hidden when no unprobed chips remain
- [ ] Kill/reopen mid-probe restores history from Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add chip probe flow from the home screen and show score results after each probe

### What Changed
- The home screen now shows a row of all chips, with badges on unprobed chips and selectable states for already probed chips
- Tapping an unprobed chip opens a new probe chat screen; tapping a probed chip toggles it on or off, with a limit of 2 selected chips
- A new home banner shows how many chips still need to be probed and starts the next probe
- The probe screen now streams answers, shows progress dots, supports sending replies, and opens a score sheet when the probe finishes
- The score sheet shows the chip score, short story, and actions to return to matches or keep exploring
- Chip selections are now saved using chip IDs and category IDs, so the right chips stay selected after returning to home

### Impact
`✅ Faster access to chip probes from home`
`✅ Clearer chip progress and selection states`
`✅ Correct chip selections after saving and returning`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=eEsigonCv7yeByG078QUDdUZ7UYsChX5QWtmD2hgsLE&org=haran2248)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vibe Check feature—an interactive assessment flow where users can engage with chip-based probes through real-time chat.
  * Introduced chip selection management on the home screen with visual status indicators and a banner promoting new probes.
  * Added score calculation and results display with personalized story feedback upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->